### PR TITLE
restore support for IPv4 addresses, issue #10

### DIFF
--- a/index.js
+++ b/index.js
@@ -63,7 +63,7 @@ var parseMultiServerAddress = function (data) {
   if(data[1][0] !== 'shs') return false
 
   var port = +data[0][data[0].length - 1] //last item is port, handle ipv6
-  var host = data[0].slice(1, data[0].length - 2).join(':') //ipv6
+  var host = data[0].slice(1, data[0].length - 1).join(':') //ipv6
   var key = '@'+data[1][1]+'.ed25519'
   var seed = data[1][2]
 

--- a/test/index.js
+++ b/test/index.js
@@ -29,7 +29,6 @@ tape('ipv6 invite', function (t) {
   t.end()
 })
 
-return
 tape('multiserver invite', function (t) {
   var rand = Math.random()
   t.ok(R.isMultiServerInvite(invite1))


### PR DESCRIPTION
I'm assuming #10 was unintended and I'm taking the proactive option and just fixing it. I hope the tests can be trusted now also for IPv6.