### PR TITLE
add normalizeChannel helper for consistent indexing/display across clients

### DIFF
--- a/index.js
+++ b/index.js
@@ -48,6 +48,16 @@ var isBlobId = exports.isBlob = exports.isBlobId =
     return isString(data) && blobIdRegex.test(data)
   }
 
+var normalizeChannel = exports.normalizeChannel =
+  function (data) {
+    if (typeof data === 'string') {
+      data = data.toLowerCase().replace(/\s/g, '')
+      if (data.length > 0 && data.length < 30) {
+        return data
+      }
+    }
+  }
+
 var multiServerAddressRegex = /^\w+\:.+~shs\:/
 var parseMultiServerAddress = function (data) {
   if(!isString(data)) return false


### PR DESCRIPTION
I'm using this function in quite a few places, and it should really be consistent across clients, so I've added it to `ssb-ref`.

- enforce max length of 30
- lowercase
- no spaces

When merged, will be used in ssb-backlinks, patchwork, patchcore

Okay if I merge @clehner @dominictarr ?