### PR TITLE
support secret blobs and add parseBlob

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,10 +1,11 @@
 var isDomain = require('is-valid-domain')
+var Querystring = require('querystring')
 var ip = require('ip')
 var protocolRegex = /^(net|wss?|onion)$/
 var linkRegex = exports.linkRegex = /^(@|%|&)[A-Za-z0-9\/+]{43}=\.[\w\d]+$/
 var feedIdRegex = exports.feedIdRegex = /^@[A-Za-z0-9\/+]{43}=\.(?:sha256|ed25519)$/
 var msgIdRegex = exports.msgIdRegex = /^%[A-Za-z0-9\/+]{43}=\.sha256$/
-var blobIdRegex = exports.blobIdRegex = /^(&[A-Za-z0-9\/+]{43}=\.sha256)(\?unbox=([0-9a-zA-Z\/+]{43}=)(\.boxs)?)?$/
+var blobIdRegex = exports.blobIdRegex = /^(&[A-Za-z0-9\/+]{43}=\.sha256)(\?(.+))?$/
 var multiServerAddressRegex = /^\w+\:.+~shs\:/
 var extractRegex = /([@%&][A-Za-z0-9\/+]{43}=\.[\w\d]+)/
 
@@ -160,9 +161,9 @@ exports.parseBlob = function parseBlob (ref) {
   var match = blobIdRegex.exec(ref)
   if (match && match[1]) {
     if (match[3]) {
-      return {id: match[1], key: match[3]}
+      return {link: match[1], query: Querystring.parse(match[3])}
     } else {
-      return {id: match[1]}
+      return {link: match[1]}
     }
   }
 }

--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ var protocolRegex = /^(net|wss?|onion)$/
 var linkRegex = exports.linkRegex = /^(@|%|&)[A-Za-z0-9\/+]{43}=\.[\w\d]+$/
 var feedIdRegex = exports.feedIdRegex = /^@[A-Za-z0-9\/+]{43}=\.(?:sha256|ed25519)$/
 var msgIdRegex = exports.msgIdRegex = /^%[A-Za-z0-9\/+]{43}=\.sha256$/
-var blobIdRegex = exports.blobIdRegex = /^&[A-Za-z0-9\/+]{43}=\.sha256$/
+var blobIdRegex = exports.blobIdRegex = /^(&[A-Za-z0-9\/+]{43}=\.sha256)(\?unbox=([0-9a-zA-Z\/+]{43}=)(\.boxs)?)?$/
 var multiServerAddressRegex = /^\w+\:.+~shs\:/
 var extractRegex = /([@%&][A-Za-z0-9\/+]{43}=\.[\w\d]+)/
 
@@ -156,6 +156,16 @@ var isInvite = exports.isInvite =
     return isLegacyInvite(data) || isMultiServerInvite(data)
   }
 
+exports.parseBlob = function parseBlob (ref) {
+  var match = blobIdRegex.exec(ref)
+  if (match && match[1]) {
+    if (match[3]) {
+      return {id: match[1], key: match[3]}
+    } else {
+      return {id: match[1]}
+    }
+  }
+}
 
 function parseLegacyInvite (invite) {
   var redirect = invite.split('#')

--- a/test/index.js
+++ b/test/index.js
@@ -16,6 +16,9 @@ var ipv6Invite = "2a03:2267::ba27:ebff:fe8c:5a4d:8080:@gYCJpN4eGDjHFnWW2Fcusj8O4
 var ipv6AddrLocal = "::1:8080:@gYCJpN4eGDjHFnWW2Fcusj8O4QYbVDUW6rNYh7nNEnc=.ed25519"
 var ipv6InviteLocal = "::1:8080:@gYCJpN4eGDjHFnWW2Fcusj8O4QYbVDUW6rNYh7nNEnc=.ed25519~DxiHEv+ds+zUzA49efDgZk8ssGeqrp/5kgvRVzTM7vU="
 
+var blob = "&abcdefg6bIh5dmyss7QH7uMrQxz3LKvgjer68we30aQ=.sha256"
+var secretBlob = "&abcdefg6bIh5dmyss7QH7uMrQxz3LKvgjer68we30aQ=.sha256?unbox=abcdefgqAYfzLrychmP5KchZ6JaLHyYv1aYOviDnSZk=.boxs"
+
 var R = require('../')
 var tape = require('tape')
 
@@ -165,12 +168,22 @@ tape('extract', function (t) {
   t.end()
 })
 
+tape('blob', function (t) {
+  t.ok(R.isBlob(blob))
+  t.ok(R.isBlob(secretBlob))
+  t.notOk(R.isBlob(secretBlob.slice(0, -3)))
 
+  t.deepEqual(R.parseBlob(blob), {
+    id: blob
+  })
 
+  t.deepEqual(R.parseBlob(secretBlob), {
+    id: "&abcdefg6bIh5dmyss7QH7uMrQxz3LKvgjer68we30aQ=.sha256",
+    key: "abcdefgqAYfzLrychmP5KchZ6JaLHyYv1aYOviDnSZk="
+  })
 
-
-
-
+  t.end()
+})
 
 
 

--- a/test/index.js
+++ b/test/index.js
@@ -17,7 +17,7 @@ var ipv6AddrLocal = "::1:8080:@gYCJpN4eGDjHFnWW2Fcusj8O4QYbVDUW6rNYh7nNEnc=.ed25
 var ipv6InviteLocal = "::1:8080:@gYCJpN4eGDjHFnWW2Fcusj8O4QYbVDUW6rNYh7nNEnc=.ed25519~DxiHEv+ds+zUzA49efDgZk8ssGeqrp/5kgvRVzTM7vU="
 
 var blob = "&abcdefg6bIh5dmyss7QH7uMrQxz3LKvgjer68we30aQ=.sha256"
-var secretBlob = "&abcdefg6bIh5dmyss7QH7uMrQxz3LKvgjer68we30aQ=.sha256?unbox=abcdefgqAYfzLrychmP5KchZ6JaLHyYv1aYOviDnSZk=.boxs"
+var secretBlob = "&abcdefg6bIh5dmyss7QH7uMrQxz3LKvgjer68we30aQ=.sha256?unbox=abcdefgqAYfzLrychmP5KchZ6JaLHyYv1aYOviDnSZk=.boxs&another=test"
 
 var R = require('../')
 var tape = require('tape')
@@ -171,15 +171,17 @@ tape('extract', function (t) {
 tape('blob', function (t) {
   t.ok(R.isBlob(blob))
   t.ok(R.isBlob(secretBlob))
-  t.notOk(R.isBlob(secretBlob.slice(0, -3)))
 
   t.deepEqual(R.parseBlob(blob), {
-    id: blob
+    link: blob
   })
 
   t.deepEqual(R.parseBlob(secretBlob), {
-    id: "&abcdefg6bIh5dmyss7QH7uMrQxz3LKvgjer68we30aQ=.sha256",
-    key: "abcdefgqAYfzLrychmP5KchZ6JaLHyYv1aYOviDnSZk="
+    link: "&abcdefg6bIh5dmyss7QH7uMrQxz3LKvgjer68we30aQ=.sha256",
+    query: {
+      unbox: "abcdefgqAYfzLrychmP5KchZ6JaLHyYv1aYOviDnSZk=.boxs",
+      another: "test"
+    }
   })
 
   t.end()


### PR DESCRIPTION
This PR adds support for detecting secret blobs using `isBlob`. 

It also adds a new `parseBlob` export that when given a blob ref, returns an object containing `{id, key}`.

```js
var ref = require('ssb-ref')
var secretBlob = '&abcdefg6bIh5dmyss7QH7uMrQxz3LKvgjer68we30aQ=.sha256?unbox=abcdefgqAYfzLrychmP5KchZ6JaLHyYv1aYOviDnSZk=.boxs'
ref.parseBlob(secretBlob) // => {
//    id: "&abcdefg6bIh5dmyss7QH7uMrQxz3LKvgjer68we30aQ=.sha256",
//    key: "abcdefgqAYfzLrychmP5KchZ6JaLHyYv1aYOviDnSZk="
//  }
```

I plan to use this in ssb-mentions and patchcore, rather than using slightly differing hand-rolled implementations that are currently there.

cc @clehner @dominictarr 