### PR TITLE
use parseLink instead, and allow query on all refs

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,10 +2,11 @@ var isDomain = require('is-valid-domain')
 var Querystring = require('querystring')
 var ip = require('ip')
 var protocolRegex = /^(net|wss?|onion)$/
-var linkRegex = exports.linkRegex = /^((@|%|&)[A-Za-z0-9\/+]{43}=\.[\w\d]+)(\?(.+))?$/
-var feedIdRegex = exports.feedIdRegex = /^@[A-Za-z0-9\/+]{43}=\.(?:sha256|ed25519)(\?.+)?$/
-var msgIdRegex = exports.msgIdRegex = /^%[A-Za-z0-9\/+]{43}=\.sha256(\?.+)?$/
-var blobIdRegex = exports.blobIdRegex = /^&[A-Za-z0-9\/+]{43}=\.sha256(\?.+)?$/
+var parseLinkRegex = /^((@|%|&)[A-Za-z0-9\/+]{43}=\.[\w\d]+)(\?(.+))?$/
+var linkRegex = exports.linkRegex = /^(@|%|&)[A-Za-z0-9\/+]{43}=\.[\w\d]+$/
+var feedIdRegex = exports.feedIdRegex = /^@[A-Za-z0-9\/+]{43}=\.(?:sha256|ed25519)$/
+var msgIdRegex = exports.msgIdRegex = /^%[A-Za-z0-9\/+]{43}=\.sha256$/
+var blobIdRegex = exports.blobIdRegex = /^&[A-Za-z0-9\/+]{43}=\.sha256$/
 var multiServerAddressRegex = /^\w+\:.+~shs\:/
 var extractRegex = /([@%&][A-Za-z0-9\/+]{43}=\.[\w\d]+)/
 
@@ -158,7 +159,7 @@ var isInvite = exports.isInvite =
   }
 
 exports.parseLink = function parseBlob (ref) {
-  var match = linkRegex.exec(ref)
+  var match = parseLinkRegex.exec(ref)
   if (match && match[1]) {
     if (match[3]) {
       return {link: match[1], query: Querystring.parse(match[4])}

--- a/index.js
+++ b/index.js
@@ -2,10 +2,10 @@ var isDomain = require('is-valid-domain')
 var Querystring = require('querystring')
 var ip = require('ip')
 var protocolRegex = /^(net|wss?|onion)$/
-var linkRegex = exports.linkRegex = /^(@|%|&)[A-Za-z0-9\/+]{43}=\.[\w\d]+$/
-var feedIdRegex = exports.feedIdRegex = /^@[A-Za-z0-9\/+]{43}=\.(?:sha256|ed25519)$/
-var msgIdRegex = exports.msgIdRegex = /^%[A-Za-z0-9\/+]{43}=\.sha256$/
-var blobIdRegex = exports.blobIdRegex = /^(&[A-Za-z0-9\/+]{43}=\.sha256)(\?(.+))?$/
+var linkRegex = exports.linkRegex = /^((@|%|&)[A-Za-z0-9\/+]{43}=\.[\w\d]+)(\?(.+))?$/
+var feedIdRegex = exports.feedIdRegex = /^@[A-Za-z0-9\/+]{43}=\.(?:sha256|ed25519)(\?.+)?$/
+var msgIdRegex = exports.msgIdRegex = /^%[A-Za-z0-9\/+]{43}=\.sha256(\?.+)?$/
+var blobIdRegex = exports.blobIdRegex = /^&[A-Za-z0-9\/+]{43}=\.sha256(\?.+)?$/
 var multiServerAddressRegex = /^\w+\:.+~shs\:/
 var extractRegex = /([@%&][A-Za-z0-9\/+]{43}=\.[\w\d]+)/
 
@@ -157,11 +157,11 @@ var isInvite = exports.isInvite =
     return isLegacyInvite(data) || isMultiServerInvite(data)
   }
 
-exports.parseBlob = function parseBlob (ref) {
-  var match = blobIdRegex.exec(ref)
+exports.parseLink = function parseBlob (ref) {
+  var match = linkRegex.exec(ref)
   if (match && match[1]) {
     if (match[3]) {
-      return {link: match[1], query: Querystring.parse(match[3])}
+      return {link: match[1], query: Querystring.parse(match[4])}
     } else {
       return {link: match[1]}
     }

--- a/test/index.js
+++ b/test/index.js
@@ -18,6 +18,7 @@ var ipv6InviteLocal = "::1:8080:@gYCJpN4eGDjHFnWW2Fcusj8O4QYbVDUW6rNYh7nNEnc=.ed
 
 var blob = "&abcdefg6bIh5dmyss7QH7uMrQxz3LKvgjer68we30aQ=.sha256"
 var secretBlob = "&abcdefg6bIh5dmyss7QH7uMrQxz3LKvgjer68we30aQ=.sha256?unbox=abcdefgqAYfzLrychmP5KchZ6JaLHyYv1aYOviDnSZk=.boxs&another=test"
+var secretMessage = "%abcdefg6bIh5dmyss7QH7uMrQxz3LKvgjer68we30aQ=.sha256?unbox=abcdefgqAYfzLrychmP5KchZ6JaLHyYv1aYOviDnSZk=.boxs"
 
 var R = require('../')
 var tape = require('tape')
@@ -168,15 +169,25 @@ tape('extract', function (t) {
   t.end()
 })
 
+tape('parse link', function (t) {
+  t.deepEqual(R.parseLink(secretMessage), {
+    link: "%abcdefg6bIh5dmyss7QH7uMrQxz3LKvgjer68we30aQ=.sha256",
+    query: {
+      unbox: "abcdefgqAYfzLrychmP5KchZ6JaLHyYv1aYOviDnSZk=.boxs"
+    }
+  })
+  t.end()
+})
+
 tape('blob', function (t) {
   t.ok(R.isBlob(blob))
   t.ok(R.isBlob(secretBlob))
 
-  t.deepEqual(R.parseBlob(blob), {
+  t.deepEqual(R.parseLink(blob), {
     link: blob
   })
 
-  t.deepEqual(R.parseBlob(secretBlob), {
+  t.deepEqual(R.parseLink(secretBlob), {
     link: "&abcdefg6bIh5dmyss7QH7uMrQxz3LKvgjer68we30aQ=.sha256",
     query: {
       unbox: "abcdefgqAYfzLrychmP5KchZ6JaLHyYv1aYOviDnSZk=.boxs",

--- a/test/index.js
+++ b/test/index.js
@@ -181,11 +181,18 @@ tape('parse link', function (t) {
 
 tape('blob', function (t) {
   t.ok(R.isBlob(blob))
-  t.ok(R.isBlob(secretBlob))
 
-  t.deepEqual(R.parseLink(blob), {
+  // shouldn't accept a blob with a query string
+  // this should be handled by parseLink
+  t.notOk(R.isBlob(secretBlob))
+
+  var link = R.parseLink(blob)
+
+  t.deepEqual(link, {
     link: blob
   })
+
+  t.ok(R.isBlob(link.link))
 
   t.deepEqual(R.parseLink(secretBlob), {
     link: "&abcdefg6bIh5dmyss7QH7uMrQxz3LKvgjer68we30aQ=.sha256",


### PR DESCRIPTION
I hastily merged and published #15 as v2.10.0, but now I realise that @dominictarr was suggesting that we allow query on all ref types.

This PR adds support for handling query strings on all ref types, and adds a `parseLink` method which allows you to access this in the form of `{link: "id...", query: {param: "value"}}`

So I have unpublished 2.10.0 and submit this instead. The reason I unpublished is that this PR contains a breaking change to 2.10.0 where I'm using a generic `parseLink` instead of `parseBlob`.