### PR TITLE
fix extract on non encoded urls when ID starts with number

### DIFF
--- a/index.js
+++ b/index.js
@@ -249,12 +249,18 @@ exports.extract =
       return false
 
     var _data = data
-    try { _data = decodeURIComponent(data) }
-    catch (e) {} // this may fail if it's not encoded, so don't worry if it does
-    _data = _data.replace(/&amp;/g, '&')
 
     var res = extractRegex.exec(_data)
-    return res && res[0]
+    if (res) {
+      return res && res[0]
+    } else {
+      try { _data = decodeURIComponent(data) }
+      catch (e) {} // this may fail if it's not encoded, so don't worry if it does
+      _data = _data.replace(/&amp;/g, '&')
+  
+      var res = extractRegex.exec(_data)
+      return res && res[0]
+    }
   }
 
 

--- a/test/index.js
+++ b/test/index.js
@@ -156,6 +156,15 @@ var blobUrls = [
   'http://localhost:7777/&amp;51ZXxNYIvTDCoNTE9R94NiEg3JAZAxWtKn4h4SmBwyY=.sha256?foo=bar'
 ]
 
+tape('extract with non url-encoded links', function (t) {
+  var messageIdWithNumberAtStart = '%09abcdefghyq9KH6dYMc/g17L04jDbl1py8arGQmL1I=.sha256'
+  t.equal(R.extract(messageIdWithNumberAtStart), messageIdWithNumberAtStart)
+  t.equal(R.extract(encodeURIComponent(messageIdWithNumberAtStart)), messageIdWithNumberAtStart)
+  t.equal(R.extract(encodeURIComponent(msgRef)), msgRef)
+  t.equal(R.extract(msgRef), msgRef)
+  t.end()
+})
+
 tape('extract', function (t) {
   msgUrls.forEach(function (url) {
     t.equal(R.extract(url), msgRef)


### PR DESCRIPTION
`extract` attempts to perform a `decodeURIComponent` on a URL before running the ref regexp against it.

The problem is that sometimes IDs can be URL decoded even when they were not encoded in the first place (e.g. ID starts with a number `%09Vq6Fa0zhyq9KH6dYMc/g17L04jDbl1py8arGQmL1I=.sha256` becomes `\tVq6Fa0zhyq9KH6dYMc/g17L04jDbl1py8arGQmL1I=.sha256`). 

This means that these URLs are not detected as links.

This PR fixes the bug by first checking to see if the URL matches the regexp before URL decoding. All tests pass.

Merging in 3, 2 ...