### PR TITLE
isMsglink, isBlobLink

### DIFF
--- a/index.js
+++ b/index.js
@@ -272,10 +272,3 @@ exports.extract =
     }
   }
 
-
-
-
-
-
-
-

--- a/index.js
+++ b/index.js
@@ -53,6 +53,15 @@ var isBlobId = exports.isBlob = exports.isBlobId =
     return isString(data) && blobIdRegex.test(data)
   }
 
+exports.isBlobLink = function (s) {
+  return s[0] === '&' && isLink(s)
+}
+
+exports.isMsgLink = function (s) {
+  return s[0] === '%' && isLink(s)
+}
+
+
 var normalizeChannel = exports.normalizeChannel =
   function (data) {
     if (typeof data === 'string') {
@@ -262,5 +271,11 @@ exports.extract =
       return res && res[0]
     }
   }
+
+
+
+
+
+
 
 


### PR DESCRIPTION
test if a string is a valid link - a message or blob id, with optional query string. so far, query string is used to carry unbox key, as used in private blobs, and candidate for [shareable private messages](https://github.com/ssbc/secure-scuttlebutt/pull/220)