### PR TITLE
Use `console.trace` on deprecation notice

### DIFF
--- a/index.js
+++ b/index.js
@@ -82,7 +82,7 @@ function deprecate (name, fn) {
   return function () {
     var args = [].slice.call(arguments)
     if(!logged) {
-      console.error('deprecated api used:'+name)
+      console.trace('deprecated api used: '+name)
       logged = true
     }
     return fn.apply(this, args)


### PR DESCRIPTION
I noticed "deprecated api used:ssb-ref.parseMultiServerAddress" in my `npm test` logs but couldn't determine where it was coming from, so I monkey-patched this and it became much easier.

## Before

```
deprecated api used:ssb-ref.parseMultiServerAddress
```

## After

```
Trace: deprecated api used: ssb-ref.parseMultiServerAddress
    at /home/christianbundy/src/ssb-ref/index.js:85:15
    at parseMultiServerInvite (/home/christianbundy/src/ssb-ref/index.js:254:14)
    at exports.isMultiServerInvite (/home/christianbundy/src/ssb-ref/index.js:211:14)
    at exports.isInvite (/home/christianbundy/src/ssb-ref/index.js:217:36)
    at Object.exports.type (/home/christianbundy/src/ssb-ref/index.js:288:13)
    at exports.isLink (/home/christianbundy/src/ssb-markdown/node_modules/ssb-msgs/index.js:129:24)
    at /home/christianbundy/src/ssb-markdown/node_modules/ssb-msgs/index.js:118:35
    at Array.filter (<anonymous>)
    at Object.exports.links.exports.asLinks (/home/christianbundy/src/ssb-markdown/node_modules/ssb-msgs/index.js:118:6)
    at Test.<anonymous> (/home/christianbundy/src/ssb-markdown/test/index.js:50:10)
```

@dominictarr Is this too loud? I love that it only appears once, that was a great call.