### PR TITLE
catch undefined crash

### DIFF
--- a/index.js
+++ b/index.js
@@ -97,6 +97,10 @@ var parseMultiServerAddress = deprecate('ssb-ref.parseMultiServerAddress', funct
   addr = addr.find(function (address) {
     return /^(net|wss?|onion)$/.test(address[0].name) && /^shs/.test(address[1].name)
   })
+  if (!Array.isArray(addr)) {
+	  console.trace('got no addr from', data)
+	  return false
+  }
   var port = +addr[0].data.pop() //last item always port, to handle ipv6
 
   //preserve protocol type on websocket addresses


### PR DESCRIPTION
somhow I'm getting `http://` urls through this code path which don't have a
multiaddr representation. addr is then false / can't be indexed and thus my node crashes.

It _looks_ like the markdown parser tries to check if these are invites or something?!

```
Trace: got no addr from http://standardjs.com/
    at /home/cryptix/ssb-ref/index.js:101:12
    at /home/cryptix/ssb-ref/index.js:88:15
    at parseMultiServerInvite (/home/cryptix/ssb-ref/index.js:258:14)
    at exports.isMultiServerInvite (/home/cryptix/ssb-ref/index.js:215:14)
    at exports.isInvite (/home/cryptix/ssb-ref/index.js:221:36)
    at Object.exports.type (/home/cryptix/ssb-ref/index.js:292:13)
    at /home/cryptix/patchbay/node_modules/ssb-backlinks/emit-links.js:20:13
    at walk (/home/cryptix/patchbay/node_modules/ssb-backlinks/emit-links.js:53:5)
    at walk (/home/cryptix/patchbay/node_modules/ssb-backlinks/emit-links.js:50:7)
    at emitLinks (/home/cryptix/patchbay/node_modules/ssb-backlinks/emit-links.js:10:3)
Trace: got no addr from https://github.com/NixOS/nixpkgs/pull/46062/files
    at /home/cryptix/ssb-ref/index.js:101:12
    at /home/cryptix/ssb-ref/index.js:88:15
    at parseMultiServerInvite (/home/cryptix/ssb-ref/index.js:258:14)
    at exports.isMultiServerInvite (/home/cryptix/ssb-ref/index.js:215:14)
    at exports.isInvite (/home/cryptix/ssb-ref/index.js:221:36)
    at Object.exports.type (/home/cryptix/ssb-ref/index.js:292:13)
    at /home/cryptix/patchbay/node_modules/ssb-backlinks/emit-links.js:20:13
    at walk (/home/cryptix/patchbay/node_modules/ssb-backlinks/emit-links.js:53:5)
    at walk (/home/cryptix/patchbay/node_modules/ssb-backlinks/emit-links.js:50:7)
    at emitLinks (/home/cryptix/patchbay/node_modules/ssb-backlinks/emit-links.js:10:3)
Trace: got no addr from https://github.com/ssbc/ssb-blobs/blob/master/inject.js
    at /home/cryptix/ssb-ref/index.js:101:12
    at /home/cryptix/ssb-ref/index.js:88:15
    at parseMultiServerInvite (/home/cryptix/ssb-ref/index.js:258:14)
    at exports.isMultiServerInvite (/home/cryptix/ssb-ref/index.js:215:14)
    at exports.isInvite (/home/cryptix/ssb-ref/index.js:221:36)
    at Object.exports.type (/home/cryptix/ssb-ref/index.js:292:13)
    at /home/cryptix/patchbay/node_modules/ssb-backlinks/emit-links.js:20:13
    at walk (/home/cryptix/patchbay/node_modules/ssb-backlinks/emit-links.js:53:5)
    at walk (/home/cryptix/patchbay/node_modules/ssb-backlinks/emit-links.js:50:7)
    at emitLinks (/home/cryptix/patchbay/node_modules/ssb-backlinks/emit-links.js:10:3)
```