### PR TITLE
re-add regexp exporting

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,9 +5,9 @@ var ip = require('ip')
 
 var parseLinkRegex = /^((@|%|&)[A-Za-z0-9\/+]{43}=\.[\w\d]+)(\?(.+))?$/
 var linkRegex = exports.linkRegex = /^(@|%|&)[A-Za-z0-9\/+]{43}=\.[\w\d]+$/
-var feedIdRegex = isCanonicalBase64('@', '\.(?:sha256|ed25519)', 32)
-var blobIdRegex = isCanonicalBase64('&', '\.sha256', 32)
-var msgIdRegex = isCanonicalBase64('%', '\.sha256', 32)
+var feedIdRegex = exports.feedIdRegex = isCanonicalBase64('@', '\.(?:sha256|ed25519)', 32)
+var blobIdRegex = exports.blobIdRegex = isCanonicalBase64('&', '\.sha256', 32)
+var msgIdRegex = exports.msgIdRegex = isCanonicalBase64('%', '\.sha256', 32)
 
 var extractRegex = /([@%&][A-Za-z0-9\/+]{43}=\.[\w\d]+)/
 


### PR DESCRIPTION
@dominictarr this is a courtesy PR and also just a satefy check.

I'm adding exporting of regexps back in because I've been depending on these quite a lot to build JSON-schema, and without these pretty much every schema I've written breaks unless I use an old version of ssb-ref 