### PR TITLE
add basic fix to stop errors in multiserver parsing

### DIFF
--- a/index.js
+++ b/index.js
@@ -106,6 +106,8 @@ var parseMultiServerAddress = deprecate('ssb-ref.parseMultiServerAddress', funct
 
   var addr = MultiServerAddress.decode(data)
   addr = addr.find(function (address) {
+    if (!address[0]) return false
+    if (!address[1]) return false
     return /^(net|wss?|onion)$/.test(address[0].name) && /^shs/.test(address[1].name)
   })
   if (!Array.isArray(addr)) {


### PR DESCRIPTION
**Problem** : fresh installs or re-indexes currently explode, because `address[1]` is `undefined`. This brings the whole app to a halt and the interface is completely un-useable because the indexing never finishes.

I don't know if this is a good solutions but it's an interim solution which lets my interface load.
I'm going to publish this immediately because the current HEAD is so breaking.