### PR TITLE
accept legacy addresses as objects `isAddress({key, host, port})`

### DIFF
--- a/index.js
+++ b/index.js
@@ -155,20 +155,18 @@ var toMultiServerAddress = exports.toMultiServerAddress = function (addr) {
 var isAddress = exports.isAddress = function (data) {
   var host, port, id
   if(isObject(data)) {
-    id = data.key
-    host = data.host
-    port = data.port
+    id = data.key; host = data.host; port = data.port
   }
   else if(!isString(data)) return false
   else if(isMultiServerAddress(data)) return true
   else {
     var parts = data.split(':')
-    var id = parts.pop(), port = parts.pop(), host = parts.join(':')
-    return (
-      isFeedId(id) && isPort(+port)
-      && isHost(host)
-    )
+    id = parts.pop(); port = parts.pop(); host = parts.join(':')
   }
+  return (
+    isFeedId(id) && isPort(+port)
+    && isHost(host)
+  )
 }
 
 //This is somewhat fragile, because maybe non-shs protocols get added...
@@ -331,6 +329,10 @@ exports.extract =
       return res && res[0]
     }
   }
+
+
+
+
 
 
 

--- a/test/index.js
+++ b/test/index.js
@@ -120,12 +120,18 @@ tape('legacy invite', function (t) {
 
 tape('parse multiserver address to legacy', function (t) {
 
-  t.ok(R.isAddress(multiserver1))
-  t.deepEqual(R.parseAddress(multiserver1), {
+  var objAddr = {
     host: "145.12.20.3",
     port :8080,
     key: "@gYCJpN4eGDjHFnWW2Fcusj8O4QYbVDUW6rNYh7nNEnc=.ed25519"
-  })
+  }
+
+  t.ok(R.isAddress(multiserver1))
+  t.deepEqual(R.parseAddress(multiserver1), objAddr)
+
+  t.ok(R.isAddress(objAddr))
+  t.notOk(R.isAddress({}))
+
 
   t.end()
 
@@ -200,8 +206,6 @@ tape('parse link', function (t) {
   t.end()
 })
 
-
-
 tape('blob', function (t) {
   t.ok(R.isBlob(blob))
 
@@ -243,15 +247,6 @@ tape('urls', function (t) {
 
   t.end()
 })
-
-
-
-
-
-
-
-
-
 
 
 


### PR DESCRIPTION
Turns out sbot was using this, https://github.com/ssbc/scuttlebot/blob/master/plugins/gossip/init.js#L23
but since this way of calling `isAddress` never had test coverage, and 2.13 changed this, it meant that sbot did not rebuild it's peers list from pub messages.

I'm will publish this as a patch - I think it may fix the sbot@13 incompatiblitiy